### PR TITLE
Make the plugin compatible with Gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,6 @@ sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
-    maven {
-        url ('https://dl.bintray.com/kotlin/dokka')
-    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.4.31'
-    ext.dokka_version = '0.10.0'
+    ext.dokka_version = '1.4.32'
 
     repositories {
         mavenCentral()
@@ -35,10 +35,6 @@ dependencies {
         exclude module: 'logback-classic'
     }
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-}
-
-dokka {
-    outputFormat = "javadoc"
 }
 
 gradlePlugin {
@@ -86,7 +82,7 @@ publishing {
 
 afterEvaluate {
     javadoc.enabled = false
-    publishPluginJavaDocsJar.from(dokka)
+    publishPluginJavaDocsJar.from(dokkaJavadoc)
 }
 
 compileKotlin {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ group 'com.github.dimamura'
 version '1.1.3-SNAPSHOT.0.6'
 
 apply plugin: 'kotlin'
-apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'org.jetbrains.dokka'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionSha256Sum=0e46229820205440b48a5501122002842b82886e76af35f0f3a069243dca4b3c
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/github/fhermansson/gradle/assertj/plugin/GenerateAssertions.kt
+++ b/src/main/kotlin/com/github/fhermansson/gradle/assertj/plugin/GenerateAssertions.kt
@@ -59,14 +59,14 @@ open class GenerateAssertions : DefaultTask(), ProjectEvaluationListener {
      * The sourceSet containing classes to generate assertions for.
      */
     var sourceSet: SourceSet? = null
-        @Input
+        @Internal
         get() = field ?: extension.sourceSet
 
     /**
      * The target sourceSet for generated assertions.
      */
     var testSourceSet: SourceSet? = null
-        @Input
+        @Internal
         get() = field ?: extension.testSourceSet
 
     /**


### PR DESCRIPTION
The plugin isn't currently compatible with Gradle 7; I see errors of the form:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task :generateAssertions'.
> Unable to store input properties for task ':generateAssertions'. Property 'sourceSet' with value 'source set 'main'' cannot be serialized.
```

This happens because the GenerateAssertions class had acquired an `@Input` annotation on the sourceSet properties in commit 44a5143169a9ef88767ddb6ebf4e5dcc21858663.  Replacing this with `@Internal` fixes the problem.

This PR also upgrades the plugin's build itself to Gradle 7.0.2 (removing the long-deprecated `maven` plugin, and upgrading the dokka plugin), and reverts c0b6706c7918ece4fe747478d2024b1202a3a839, since dokka is now available at maven central.
